### PR TITLE
Fix unintentional remapping of Rubric #jumpToNextKeywordOfIt

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -120,7 +120,7 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		do: [ :target | target editor jumpToNextKeywordOfIt: true ]
 		description: 'Jump to next keyword'.
 		
-	(aBuilder shortcut: #jumpToNextKeywordOfIt)
+	(aBuilder shortcut: #jumpToPrevKeywordOfIt)
 		category: RubSmalltalkEditor name
 		default: $j shift meta
 		do: [ :target | target editor jumpToNextKeywordOfIt: false ]


### PR DESCRIPTION
Fixes #6323

Shortcut symbols must be unique; RubSmalltalkEditor maps #jumpToNextKeywordOfIt, then immediately remaps it. The second mapping should be to #jumptoPrevKeywordOfIt